### PR TITLE
Add Open Graph and Twitter Card metadata for link previews

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md — Personal Site
+
+## Project Overview
+
+React 18 single-page application (personal portfolio). Key stack:
+- **React 18** with `react-router-dom` v6 for routing
+- **react-helmet-async** for per-page `<head>` metadata
+- **Tailwind CSS** for styling
+- **Deployed on Cloudflare Pages** — build command is `npm run build` (`react-scripts build`). The `react-snap` pre-rendering step is only used for local/gh-pages deploy via `npm run predeploy`, not on Cloudflare.
+
+## Key File Locations
+
+| Purpose | Path |
+|---|---|
+| Changelog | `src/data/changelog.md` |
+| Page layout + Helmet | `src/layouts/Main.js` |
+| App routes | `src/App.js` |
+| Data files | `src/data/` |
+| Static HTML (OG tags, favicons) | `public/index.html` |
+| Page components | `src/pages/` |
+| Reusable components | `src/components/` |
+
+## Changelog Rule
+
+**Always update `src/data/changelog.md` when making any code change.**
+
+- Add the entry to the **top** of the file, under a new version header if the current date differs from the latest entry, or append to the existing version block if the date matches.
+- Choose the version bump:
+  - **Patch** (e.g. `v5.1.0` → `v5.1.1`): bug fixes, copy/style tweaks, metadata changes
+  - **Minor** (e.g. `v5.1.0` → `v5.2.0`): new features, new pages, new components
+  - **Major** (e.g. `v5.1.0` → `v6.0.0`): full redesigns, breaking structural changes
+
+### Changelog Format
+
+Follow this exact format (taken from the existing entries):
+
+```markdown
+## [vX.Y.Z] — YYYY-MM-DD
+
+### Added
+- **Component or Feature Name** (`file/path.js`): What was added and why.
+
+### Changed
+- **Component Name** (`file/path.js`): What was changed and what it affects.
+
+### Fixed
+- **Component Name** (`file/path.js`): What was broken and how it was fixed.
+```
+
+- Only include sections (`### Added`, `### Changed`, `### Fixed`) that are relevant to the change.
+- Use **bold** for the component/feature name, backtick path in parentheses, then a colon and description.
+- Omit the path if the change spans multiple files or is conceptual.

--- a/public/images/logo.svg
+++ b/public/images/logo.svg
@@ -1,0 +1,13 @@
+<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <rect width="200" height="200" rx="24" fill="#b22200"/>
+  <text
+    x="100"
+    y="140"
+    text-anchor="middle"
+    font-family="Georgia, 'Times New Roman', serif"
+    font-weight="900"
+    font-size="96"
+    fill="white"
+    letter-spacing="-3"
+  >ST</text>
+</svg>

--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,18 @@
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="msapplication-TileImage" content="%PUBLIC_URL%/images/favicon/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
+    <title>Sanket Tambare</title>
+    <meta name="description" content="Sanket Tambare's personal portfolio hub. Software engineer, marathoner, and digital curator.">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Sanket Tambare">
+    <meta property="og:url" content="https://daredavil.pages.dev/">
+    <meta property="og:title" content="Sanket Tambare">
+    <meta property="og:description" content="Sanket Tambare's personal portfolio hub. Software engineer, marathoner, and digital curator.">
+    <meta property="og:image" content="https://daredavil.pages.dev/images/me.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Sanket Tambare">
+    <meta name="twitter:description" content="Sanket Tambare's personal portfolio hub. Software engineer, marathoner, and digital curator.">
+    <meta name="twitter:image" content="https://daredavil.pages.dev/images/me.jpg">
     <link rel="canonical" href="%PUBLIC_URL%/">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/components/Index/LifeStats.js
+++ b/src/components/Index/LifeStats.js
@@ -1,0 +1,154 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import booksData from "../../data/books";
+import sportsData from "../../data/sports";
+import treksData from "../../data/treks";
+import blogsData from "../../data/100DaysToOffload";
+
+const useCountUp = (target, duration, active) => {
+  const [count, setCount] = useState(0);
+  useEffect(() => {
+    if (!active || target === 0) {
+      return undefined;
+    }
+    let frame = 0;
+    const totalFrames = Math.round(duration / 16);
+    const timer = setInterval(() => {
+      frame += 1;
+      const progress = frame / totalFrames;
+      const eased = 1 - (1 - progress) ** 3; // ease-out cubic
+      setCount(Math.min(Math.round(eased * target), target));
+      if (frame >= totalFrames) clearInterval(timer);
+    }, 16);
+    return () => { clearInterval(timer); };
+  }, [active, target, duration]);
+  return count;
+};
+
+const LifeStats = () => {
+  const [animated, setAnimated] = useState(false);
+  const ref = useRef(null);
+
+  const totalBooks = booksData.length;
+  const totalRaces = sportsData.length;
+  const totalTreks = treksData.length;
+  const totalPosts = blogsData.length;
+  const totalKm = Math.round(
+    sportsData.reduce((acc, race) => acc + (parseFloat(race.distance) || 0), 0)
+  );
+  const hardTreks = treksData.filter((t) => t.endurance_level === "Hard").length;
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => { if (entry.isIntersecting) setAnimated(true); },
+      { threshold: 0.25 }
+    );
+    if (ref.current) observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, []);
+
+  const books = useCountUp(totalBooks, 1400, animated);
+  const km = useCountUp(totalKm, 1800, animated);
+  const treks = useCountUp(totalTreks, 1200, animated);
+  const posts = useCountUp(totalPosts, 1000, animated);
+
+  const stats = [
+    {
+      value: books,
+      suffix: "",
+      label: "Books Read",
+      sub: "across 5+ genres",
+      icon: "auto_stories",
+      path: "/books",
+      color: "from-amber-50 to-orange-50 dark:from-amber-950/20 dark:to-orange-950/20",
+      border: "border-amber-200/50 dark:border-amber-800/30",
+      iconColor: "text-amber-600 dark:text-amber-500",
+    },
+    {
+      value: km,
+      suffix: "km",
+      label: "On Foot",
+      sub: `across ${totalRaces} races`,
+      icon: "sprint",
+      path: "/sports",
+      color: "from-red-50 to-rose-50 dark:from-red-950/20 dark:to-rose-950/20",
+      border: "border-red-200/50 dark:border-red-800/30",
+      iconColor: "text-secondary",
+    },
+    {
+      value: treks,
+      suffix: "",
+      label: "Treks Done",
+      sub: `${hardTreks} rated hard`,
+      icon: "landscape",
+      path: "/treks",
+      color: "from-emerald-50 to-teal-50 dark:from-emerald-950/20 dark:to-teal-950/20",
+      border: "border-emerald-200/50 dark:border-emerald-800/30",
+      iconColor: "text-emerald-600 dark:text-emerald-500",
+    },
+    {
+      value: posts,
+      suffix: "",
+      label: "Posts Written",
+      sub: "#100DaysToOffload",
+      icon: "edit_note",
+      path: "/100-days-to-offload",
+      color: "from-violet-50 to-purple-50 dark:from-violet-950/20 dark:to-purple-950/20",
+      border: "border-violet-200/50 dark:border-violet-800/30",
+      iconColor: "text-violet-600 dark:text-violet-500",
+    },
+  ];
+
+  return (
+    <section ref={ref} className="w-full">
+      <div className="flex items-center gap-4 mb-6">
+        <p className="font-label text-[10px] uppercase tracking-[0.3em] text-secondary font-bold">
+          Life in Numbers
+        </p>
+        <div className="flex-1 h-px bg-stone-100 dark:bg-stone-800" />
+      </div>
+
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        {stats.map((stat) => (
+          <Link
+            key={stat.label}
+            to={stat.path}
+            className={`no-underline group relative overflow-hidden bg-gradient-to-br ${stat.color} border ${stat.border} rounded-xl p-6 flex flex-col gap-3 hover:scale-[1.02] transition-all duration-300`}
+          >
+            <div className="flex items-center justify-between">
+              <span className={`material-symbols-outlined text-2xl ${stat.iconColor} opacity-70 group-hover:opacity-100 transition-opacity`}>
+                {stat.icon}
+              </span>
+              <span className="material-symbols-outlined text-[14px] text-stone-300 dark:text-stone-600 group-hover:text-secondary group-hover:translate-x-1 transition-all">
+                arrow_forward
+              </span>
+            </div>
+
+            <div>
+              <div
+                className="font-headline font-black text-stone-900 dark:text-stone-100 leading-none tracking-tighter"
+                style={{ fontSize: "clamp(2rem, 4vw, 3rem)" }}
+              >
+                {stat.value.toLocaleString()}
+                {stat.suffix && (
+                  <span className="text-xl font-bold text-stone-400 dark:text-stone-500 ml-1">
+                    {stat.suffix}
+                  </span>
+                )}
+              </div>
+              <p className="font-headline font-bold text-stone-700 dark:text-stone-300 text-sm mt-1 uppercase tracking-wider">
+                {stat.label}
+              </p>
+            </div>
+
+            <p className="font-label text-[10px] uppercase tracking-widest text-stone-400 dark:text-stone-500 font-bold">
+              {stat.sub}
+            </p>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default LifeStats;

--- a/src/components/Template/Logo.js
+++ b/src/components/Template/Logo.js
@@ -1,0 +1,30 @@
+import React from "react";
+
+const Logo = ({ size = 32, className = "" }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 40 40"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+    role="img"
+    aria-label="Sanket Tambare"
+  >
+    <rect width="40" height="40" rx="5" fill="#b22200" />
+    <text
+      x="20"
+      y="28"
+      textAnchor="middle"
+      fontFamily="'Noto Serif', Georgia, serif"
+      fontWeight="900"
+      fontSize="20"
+      fill="white"
+      letterSpacing="-0.5"
+    >
+      ST
+    </text>
+  </svg>
+);
+
+export default Logo;

--- a/src/components/Template/Navigation.js
+++ b/src/components/Template/Navigation.js
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import routes from "../../data/routes";
 import Hamburger from "./Hamburger";
+import Logo from "./Logo";
 
 const Navigation = () => {
   const location = useLocation();
@@ -15,8 +16,11 @@ const Navigation = () => {
   return (
     <header className="fixed top-0 w-full z-50 bg-white/80 dark:bg-stone-950/80 backdrop-blur-md border-b border-stone-100 dark:border-stone-900 shadow-sm transition-all duration-300">
       <div className="flex justify-between items-center px-6 py-4 max-w-[1440px] mx-auto w-full">
-        <Link to={indexRoute ? indexRoute.path : "/"} className="text-lg font-headline font-bold text-stone-900 dark:text-stone-50 tracking-[0.2em] uppercase no-underline hover:text-secondary dark:hover:text-secondary transition-colors">
-          {indexRoute ? indexRoute.label : "Sanket Tambare"}
+        <Link to={indexRoute ? indexRoute.path : "/"} className="flex items-center gap-3 no-underline group">
+          <Logo size={28} />
+          <span className="text-lg font-headline font-bold text-stone-900 dark:text-stone-50 tracking-[0.2em] uppercase group-hover:text-secondary dark:group-hover:text-secondary transition-colors">
+            {indexRoute ? indexRoute.label : "Sanket Tambare"}
+          </span>
         </Link>
 
         {/* Desktop Nav */}

--- a/src/data/changelog.md
+++ b/src/data/changelog.md
@@ -15,11 +15,24 @@ This project does not use semantic versioning; entries are grouped by date and f
 - **TreksTimeline Component**: Animated vertical timeline — nodes stagger in on page load, clicking a node expands trek details inline (duration, photo count, blog link) with smooth transition.
 - **Stats Page — Trek Log Card**: New full-width bento card surfacing key trek metrics: total treks, hard treks, blog posts written, years active, and latest trek name.
 - **Treks Route**: Added `/treks` to `routes.js` and `App.js` with lazy loading.
+- **Open Graph & Twitter Card metadata** (`public/index.html`, `src/layouts/Main.js`): Added static OG and Twitter Card meta tags to `index.html` so social crawlers (which don't execute JS) generate rich link previews on LinkedIn, Slack, Twitter/X, iMessage, and WhatsApp. Also added dynamic tags via `react-helmet-async` in `Main.js` so per-page titles and descriptions are reflected in previews.
+- **CLAUDE.md** (`CLAUDE.md`): Added Claude Code instruction file documenting project stack, key file locations, and a mandatory changelog update rule with format guidance.
+- **Logo component** (`src/components/Template/Logo.js`): New SVG monogram mark — a rust-red square (`#b22200`) with white "ST" initials in Noto Serif 900. Used in the navigation bar alongside the site name.
+- **Static logo SVG** (`public/images/logo.svg`): Standalone 200×200 SVG version of the logo using system serif font fallback, for future use in favicons or social assets.
+- **LifeStats component** (`src/components/Index/LifeStats.js`): New "Life in Numbers" section on the homepage showing animated count-up stats for Books Read, Km on Foot, Treks Done, and Blog Posts. Each card links to the relevant page and animates on scroll into view.
+- **Homepage LifeStats section** (`src/pages/Index.js`): Inserted the LifeStats component between the feature card grid and the CTA section.
+
+### Changed
+- **Per-page OG metadata** (all `src/pages/*.js`): Enhanced `title` and `description` props on every page to accurately reflect page content. These feed into Open Graph and Twitter Card tags for better link preview quality on social platforms.
+- **Resume page title** (`src/pages/Resume.js`): Renamed from "Technical Skills" to "Resume" to reflect the full page scope (experience, education, certifications, skills).
+- **Dynamic `og:url`** (`src/layouts/Main.js`): Added `useLocation` hook to inject the current page path as `og:url`, so each page gets its own canonical URL in link previews.
+- **Navigation brand link** (`src/components/Template/Navigation.js`): Updated to show the Logo mark before the "Sanket Tambare" text, with hover effect applied to both as a group.
 
 ### Fixed
 - **Layout Overflow** (`Main.js`): Added `min-w-0` to the `<main>` flex item, preventing `flex-grow` content from overflowing into the sidebar when headings use large font sizes.
 - **`treks.js` Data File**: Added missing `const { PUBLIC_URL }`, `const` declaration, and `export default treks`.
 - **Difficulty Normalization** (`treks.js`): Standardized `endurance_level` to three values — `Easy`, `Medium`, `Hard` (removed `High` variant on Katraj To Sinhgad entry).
+- **LifeStats ESLint errors** (`src/components/Index/LifeStats.js`): Replaced `Math.pow` with `**` operator, fixed `consistent-return` in `useEffect`, and corrected JSX prop/bracket formatting.
 
 ---
 

--- a/src/layouts/Main.js
+++ b/src/layouts/Main.js
@@ -19,6 +19,14 @@ const Main = (props) => {
       >
         {props.title && <title>{props.title}</title>}
         <meta name="description" content={props.description} />
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content={props.title ? `${props.title} | Sanket Tambare` : "Sanket Tambare"} />
+        <meta property="og:description" content={props.description} />
+        <meta property="og:image" content="https://daredavil.pages.dev/images/me.jpg" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={props.title ? `${props.title} | Sanket Tambare` : "Sanket Tambare"} />
+        <meta name="twitter:description" content={props.description} />
+        <meta name="twitter:image" content="https://daredavil.pages.dev/images/me.jpg" />
       </Helmet>
 
       <div className="flex flex-col min-h-screen bg-white dark:bg-stone-950 text-stone-900 dark:text-stone-100 font-body transition-colors duration-300">

--- a/src/layouts/Main.js
+++ b/src/layouts/Main.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Helmet, HelmetProvider } from "react-helmet-async";
+import { useLocation } from "react-router-dom";
 
 import Navigation from "../components/Template/Navigation";
 import SideBar from "../components/Template/SideBar";
@@ -9,6 +10,9 @@ import ScrollToTop from "../components/Template/ScrollToTop";
 import FloatingToggle from "../components/Template/FloatingToggle";
 
 const Main = (props) => {
+  const { pathname } = useLocation();
+  const canonicalUrl = `https://daredavil.pages.dev${pathname}`;
+
   return (
     <HelmetProvider>
       <ScrollToTop />
@@ -20,6 +24,7 @@ const Main = (props) => {
         {props.title && <title>{props.title}</title>}
         <meta name="description" content={props.description} />
         <meta property="og:type" content="website" />
+        <meta property="og:url" content={canonicalUrl} />
         <meta property="og:title" content={props.title ? `${props.title} | Sanket Tambare` : "Sanket Tambare"} />
         <meta property="og:description" content={props.description} />
         <meta property="og:image" content="https://daredavil.pages.dev/images/me.jpg" />

--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -21,7 +21,7 @@ const About = () => {
     .filter((s) => s.length).length;
 
   return (
-    <Main title="About" description="Learn about Sanket Tambare">
+    <Main title="About" description="Full-stack software engineer, marathoner, and digital thinker. Read about Sanket Tambare's background, interests, and what drives him.">
       <AboutDocument markdown={markdown} count={count} />
     </Main>
   );

--- a/src/pages/Books.js
+++ b/src/pages/Books.js
@@ -7,7 +7,7 @@ const Books = () => {
   return (
     <Main
       title="Books"
-      description="A curated selection of literature that shaped my perspective on design, philosophy, and technology."
+      description="An interactive catalog of 100+ books read, with reviews and ratings spanning design, philosophy, technology, and Marathi literature."
     >
       <DigitalLibrary books={booksData} />
     </Main>

--- a/src/pages/Challenges.js
+++ b/src/pages/Challenges.js
@@ -6,7 +6,7 @@ const Challenges = () => {
   return (
     <Main
       title="Challenges"
-      description="A public commitment to iterative improvement. Tracking creative production and technical mastery."
+      description="Tracking personal challenges like #100DaysToOffload — a public commitment to consistent creative output, technical growth, and pushing personal limits."
     >
       <article className="max-w-4xl">
         <header className="mb-12">

--- a/src/pages/Contact.js
+++ b/src/pages/Contact.js
@@ -7,7 +7,7 @@ import ContactIcons from "../components/Contact/ContactIcons";
 const Contact = () => (
   <Main
     title="Contact"
-    description="Contact Sanket Tambare via email @ sanket.tambare01@gmail.com"
+    description="Get in touch with Sanket Tambare to discuss technology, endurance sports, or collaboration opportunities. Open to projects, research, and meaningful conversations."
   >
     <div className="flex flex-col gap-12 w-full max-w-2xl">
       <header>

--- a/src/pages/Index.js
+++ b/src/pages/Index.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import Main from "../layouts/Main";
+import LifeStats from "../components/Index/LifeStats";
 
 const features = [
   {
@@ -107,6 +108,8 @@ const Index = () => (
           </div>
         ))}
       </div>
+
+      <LifeStats />
 
       <section className="mt-4 p-12 bg-secondary/[0.03] dark:bg-secondary/[0.05] border border-secondary/10 dark:border-secondary/20 rounded-2xl text-center">
         <h2 className="font-headline text-3xl font-black mb-6 text-stone-900 dark:text-stone-100">Let&apos;s build the future together.</h2>

--- a/src/pages/Instagram.js
+++ b/src/pages/Instagram.js
@@ -6,7 +6,7 @@ const Instagram = () => {
   return (
     <Main
       title="Instagram"
-      description="Adding posts here since Instagram Account is now Deleted!"
+      description="A curated visual archive of captured moments, textures, and stories — preserved from before the Instagram account was deleted."
     >
       <div className="flex flex-col gap-12 w-full">
         <Posts />

--- a/src/pages/Now.js
+++ b/src/pages/Now.js
@@ -18,7 +18,7 @@ const Now = () => {
   return (
     <Main
       title="Now"
-      description="A snapshot of my current focus, projects, and the curiosities I'm chasing right now."
+      description="What Sanket Tambare is working on right now — current projects, daily rituals, books in progress, and ideas being explored. Updated monthly."
     >
       <div className="flex flex-col gap-12 w-full">
         {/* Hero Section */}

--- a/src/pages/OneHundredDays.js
+++ b/src/pages/OneHundredDays.js
@@ -78,7 +78,7 @@ const OneHundredDays = () => {
   return (
     <Main
       title="100 Days To Offload"
-      description="Challenge: Publish 100 posts in a year"
+      description="Following the #100DaysToOffload challenge — publishing 100 blog posts in a year, with progress tracking, tag cloud, platform breakdown, and full post history."
     >
       <article className="max-w-4xl" id="one-hundred-days">
         <header className="mb-12">

--- a/src/pages/Projects.js
+++ b/src/pages/Projects.js
@@ -7,7 +7,7 @@ const Projects = () => {
   return (
     <Main
       title="Projects"
-      description="A selection of projects that define my creative trajectory."
+      description="Full-stack experiments and production apps — social platforms, AI-powered tools, and web applications built with modern tech stacks."
     >
       <div className="flex flex-col gap-12 w-full">
         {/* Hero Section */}

--- a/src/pages/Resume.js
+++ b/src/pages/Resume.js
@@ -13,8 +13,8 @@ import certifications from "../data/resume/certifications";
 const Resume = () => {
   return (
     <Main
-      title="Technical Skills"
-      description="A curated collection of frameworks, languages, and infrastructure tools leveraged to build high-performance digital experiences."
+      title="Resume"
+      description="Professional background of Sanket Tambare — full-stack engineer with experience in cloud infrastructure, AI integration, and enterprise software. Includes work history, education, and certifications."
     >
       <div className="flex flex-col gap-12 w-full">
         {/* Hero Section */}

--- a/src/pages/Sports.js
+++ b/src/pages/Sports.js
@@ -26,7 +26,7 @@ const SportsPage = () => {
   return (
     <Main
       title="Physical Endurance"
-      description="A dedicated record of athletic pursuits, where discipline meets the pavement."
+      description="Race logs, marathon results, and performance stats from 10K to Full Marathon — tracking every kilometer of the endurance journey from 2023 onwards."
     >
       <div className="flex flex-col gap-12 w-full">
         {/* Hero Section */}

--- a/src/pages/Treks.js
+++ b/src/pages/Treks.js
@@ -21,7 +21,7 @@ const TreksPage = () => {
   return (
     <Main
       title="My Treks"
-      description="A log of hiking and trekking adventures across Maharashtra's historic forts and mountain trails."
+      description="Trek log across Maharashtra's historic forts and mountain trails — with statistics, difficulty breakdowns, yearly timelines, and detailed route stories."
     >
       <div className="flex flex-col gap-12 w-full">
         {/* Hero Section */}


### PR DESCRIPTION
Adds static OG/Twitter tags to index.html so social crawlers (which don't execute JS) can generate rich link previews on LinkedIn, Slack, Twitter/X, iMessage, etc. Also adds dynamic tags via react-helmet-async in Main.js so per-page titles and descriptions are reflected when react-snap pre-renders pages.