### PR TITLE
Add 100 Days to Offload entry #19 — Sadagi in the Digital World

### DIFF
--- a/src/data/100DaysToOffload.js
+++ b/src/data/100DaysToOffload.js
@@ -196,6 +196,17 @@ const data = [
     blog_link: "https://sankettambare.substack.com/p/digital-nomad-dopamine-hits",
     blog_platform: 'Substack',
     language: 'English'
+  },
+  {
+    id: 19,
+    blog_title: "Sadagi in the Digital World",
+    blog_description: "Exploring the oneness in entangled digital world!",
+    challenge_id: "100_days_to_offload",
+    blog_tags: ['100_Days_to_Offload', 'DigitalWellbeing'],
+    blog_date: '2026-04-05',
+    blog_link: "https://sankettambare.substack.com/p/sadagi-in-the-digital-world",
+    blog_platform: 'Substack',
+    language: 'English'
   }
 ];
 

--- a/src/data/changelog.md
+++ b/src/data/changelog.md
@@ -40,7 +40,7 @@ This project does not use semantic versioning; entries are grouped by date and f
 
 ---
 
-## [v5.1.0] — 2026-04-04
+## [v5.1.0] — 2026-04-05
 
 ### Added
 - **Treks Page** (`/treks`): New page documenting Maharashtra fort and mountain trek history with two views — *Statistics* and *Default View*.
@@ -68,6 +68,9 @@ This project does not use semantic versioning; entries are grouped by date and f
 - **`treks.js` Data File**: Added missing `const { PUBLIC_URL }`, `const` declaration, and `export default treks`.
 - **Difficulty Normalization** (`treks.js`): Standardized `endurance_level` to three values — `Easy`, `Medium`, `Hard` (removed `High` variant on Katraj To Sinhgad entry).
 - **LifeStats ESLint errors** (`src/components/Index/LifeStats.js`): Replaced `Math.pow` with `**` operator, fixed `consistent-return` in `useEffect`, and corrected JSX prop/bracket formatting.
+
+### Added (2026-04-05)
+- **100 Days to Offload — Entry #19** (`src/data/100DaysToOffload.js`): Added new blog post "Sadagi in the Digital World" — exploring oneness in the entangled digital world, published on Substack.
 
 ---
 


### PR DESCRIPTION
## Summary

- New blog entry added to `src/data/100DaysToOffload.js` (id: 19) — *Sadagi in the Digital World*, published on Substack on 2026-04-05
- Changelog updated (`src/data/changelog.md`) — appended to the existing `v5.1.0` block (weekly minor cap applied) and updated its date to 2026-04-05

## Test plan

- [ ] Visit `/100-days-to-offload` and confirm entry #19 "Sadagi in the Digital World" appears
- [ ] Verify the blog link opens https://sankettambare.substack.com/p/sadagi-in-the-digital-world
- [ ] Check `/changelog` to confirm the new entry is visible under v5.1.0
