### PR TITLE
docs: add Mermaid repo structure diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,49 @@ Detailed documentation is available in the `docs/` folder:
    npm start
    ```
 
+## 🗂 Repository Structure
+
+```mermaid
+graph TD
+    ROOT["🗂 personal-site/"]
+
+    ROOT --> SRC["📁 src/"]
+    ROOT --> PUBLIC["📁 public/"]
+    ROOT --> DOCS["📁 docs/"]
+    ROOT --> FUNC["📁 functions/"]
+    ROOT --> GH["📁 .github/workflows/"]
+    ROOT --> CFG["⚙️ Config Files\npackage.json · tailwind.config.js\nbabel.config.js · postcss.config.js · jest.config.js"]
+
+    SRC --> APPJS["App.js · index.js\n(entry & routes)"]
+    SRC --> COMP["📁 components/"]
+    SRC --> PGS["📁 pages/\n14 page components"]
+    SRC --> DATA["📁 data/"]
+    SRC --> LAY["📁 layouts/\nMain.js"]
+    SRC --> CTX["📁 context/\nThemeContext.js"]
+    SRC --> CSS["📁 static/css/\nSCSS modules"]
+
+    COMP --> C_T["Template/\nNavigation · Footer · Sidebar\nHamburger · Logo · ScrollToTop"]
+    COMP --> C_S["Sports/\nSportsV2 · Statistics · Modal · Utils"]
+    COMP --> C_TK["Treks/\nTimeline · Statistics · Modal"]
+    COMP --> C_R["Resume/\nExperience · Education · Skills · Certs"]
+    COMP --> C_O["About · Books · Challenges · Contact\nIndex · Instagram · Now · Projects"]
+
+    DATA --> D_JS["books.js · sports.js · treks.js\nprojects.js · contact.js · routes.js\n100DaysToOffload.js · instagram.js"]
+    DATA --> D_MD["about.md · now.md · changelog.md"]
+    DATA --> D_RES["📁 resume/\ncertifications · degrees · positions · skills"]
+    DATA --> D_ST["📁 stats/\npersonal.js"]
+
+    PUBLIC --> P_HTML["index.html\n(OG tags · favicons · meta)"]
+    PUBLIC --> P_IMG["📁 images/\nfavicon · sports · treks · projects · insta_posts"]
+    PUBLIC --> P_PDF["sanket-tambare-resume.pdf"]
+
+    GH --> W1["node.js.yml\n(CI)"]
+    GH --> W2["github-pages.yml\n(Deploy)"]
+    GH --> W3["codeql-analysis.yml\n(Security)"]
+
+    DOCS --> DOC1["setup_guide.md · architecture.md\ndeployment.md · customization.md\nfeatures.md · contributing.md"]
+```
+
 ## 🛠️ Scripts
 
 | Command | Description |

--- a/src/data/changelog.md
+++ b/src/data/changelog.md
@@ -5,6 +5,13 @@ This project does not use semantic versioning; entries are grouped by date and f
 
 ---
 
+## [v5.1.5] — 2026-04-07
+
+### Added
+- **Mermaid Repo Structure Diagram** (`README.md`): Added a `graph TD` Mermaid diagram under a new "Repository Structure" section, visualising the full directory tree — `src/` (components, pages, data, layouts, context, static), `public/`, `docs/`, `functions/`, `.github/workflows/`, and config files.
+
+---
+
 ## [v5.1.4] — 2026-04-05
 
 ### Added


### PR DESCRIPTION
Added a graph TD Mermaid diagram under a new "Repository Structure"
section showing the full directory tree across src/, public/, docs/,
functions/, .github/workflows/, and config files.

https://claude.ai/code/session_01LZYSvKADTEfVpZaps3Kb24