### PR TITLE
fix: resolve metadata issues across all routes

### DIFF
--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -131,15 +131,18 @@ export async function onRequest(context) {
   const url = new URL(request.url);
   const pathname = url.pathname.replace(/\/$/, "") || "/";
 
-  // Only process HTML navigation requests
-  const acceptHeader = request.headers.get("Accept") || "";
-  if (!acceptHeader.includes("text/html")) {
+  // Skip static asset requests (anything with a file extension).
+  // Do not use the Accept header as a gate — scrapers commonly send
+  // Accept: */* which does not contain "text/html" and would cause the
+  // middleware to bail before injecting any metadata.
+  const lastSegment = pathname.split("/").pop();
+  if (lastSegment.includes(".")) {
     return next();
   }
 
   const response = await next();
 
-  // Only rewrite HTML responses
+  // Only rewrite HTML responses (definitive gate on the actual content type).
   const contentType = response.headers.get("Content-Type") || "";
   if (!contentType.includes("text/html")) {
     return response;

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -1,18 +1,19 @@
 const BASE_URL = "https://daredavil.pages.dev";
 const DEFAULT_IMAGE = `${BASE_URL}/images/logo.png`;
+const PERSON_IMAGE = `${BASE_URL}/images/me.jpg`;
 
 const PAGE_META = {
   "/": {
     title: "Sanket Tambare",
     description:
       "Sanket Tambare's personal portfolio hub. Software engineer, marathoner, and digital curator.",
-    image: DEFAULT_IMAGE,
+    image: PERSON_IMAGE,
   },
   "/about": {
     title: "About | Sanket Tambare",
     description:
       "Full-stack software engineer, marathoner, and digital thinker. Read about Sanket Tambare's background, interests, and what drives him.",
-    image: `${BASE_URL}/images/me.jpg`,
+    image: PERSON_IMAGE,
   },
   "/books": {
     title: "Books | Sanket Tambare",
@@ -66,7 +67,7 @@ const PAGE_META = {
     title: "Resume | Sanket Tambare",
     description:
       "Professional background of Sanket Tambare — full-stack engineer with experience in cloud infrastructure, AI integration, and enterprise software.",
-    image: `${BASE_URL}/images/me.jpg`,
+    image: PERSON_IMAGE,
   },
   "/sports": {
     title: "Physical Endurance | Sanket Tambare",
@@ -88,37 +89,39 @@ const PAGE_META = {
   },
 };
 
-class MetaRewriter {
-  constructor(meta, canonicalUrl) {
-    this.meta = meta;
-    this.canonicalUrl = canonicalUrl;
-    this.titleDone = false;
+const DEFAULT_META = {
+  title: "Sanket Tambare",
+  description: "Sanket Tambare's personal website.",
+  image: DEFAULT_IMAGE,
+};
+
+function escAttr(str) {
+  return String(str).replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}
+
+// Updates the text content of the existing <title> element.
+class TitleRewriter {
+  constructor(title) {
+    this.title = title;
   }
-
   element(element) {
-    const tag = element.tagName;
+    element.setInnerContent(this.title);
+  }
+}
 
-    if (tag === "title" && !this.titleDone) {
-      element.setInnerContent(this.meta.title);
-      this.titleDone = true;
-      return;
-    }
-
-    const property = element.getAttribute("property");
-    const name = element.getAttribute("name");
-
-    if (property === "og:title" || name === "twitter:title") {
-      element.setAttribute("content", this.meta.title);
-    } else if (
-      property === "og:description" ||
-      name === "twitter:description" ||
-      name === "description"
-    ) {
-      element.setAttribute("content", this.meta.description);
-    } else if (property === "og:image" || name === "twitter:image") {
-      element.setAttribute("content", this.meta.image);
-    } else if (property === "og:url") {
-      element.setAttribute("content", this.canonicalUrl);
+// Appends all per-page meta/link tags at the end of <head>.
+// index.html no longer carries static OG/Twitter/canonical tags (they were
+// removed to prevent first-match conflicts with Helmet's client-side tags),
+// so HTMLRewriter must INSERT rather than update.
+class HeadInjector {
+  constructor(html) {
+    this.html = html;
+    this.done = false;
+  }
+  element(element) {
+    if (!this.done) {
+      element.append(this.html, { html: true });
+      this.done = true;
     }
   }
 }
@@ -134,12 +137,6 @@ export async function onRequest(context) {
     return next();
   }
 
-  const meta = PAGE_META[pathname];
-  if (!meta) {
-    return next();
-  }
-
-  const canonicalUrl = `${BASE_URL}${pathname === "/" ? "" : pathname}`;
   const response = await next();
 
   // Only rewrite HTML responses
@@ -148,11 +145,24 @@ export async function onRequest(context) {
     return response;
   }
 
-  const rewriter = new MetaRewriter(meta, canonicalUrl);
+  const meta = PAGE_META[pathname] ?? DEFAULT_META;
+  const canonicalUrl = `${BASE_URL}${pathname === "/" ? "" : pathname}`;
+
+  const tags = `
+    <link rel="canonical" href="${escAttr(canonicalUrl)}">
+    <meta name="description" content="${escAttr(meta.description)}">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="${escAttr(canonicalUrl)}">
+    <meta property="og:title" content="${escAttr(meta.title)}">
+    <meta property="og:description" content="${escAttr(meta.description)}">
+    <meta property="og:image" content="${escAttr(meta.image)}">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="${escAttr(meta.title)}">
+    <meta name="twitter:description" content="${escAttr(meta.description)}">
+    <meta name="twitter:image" content="${escAttr(meta.image)}">`;
+
   return new HTMLRewriter()
-    .on("title", rewriter)
-    .on("meta[name='description']", rewriter)
-    .on("meta[property^='og:']", rewriter)
-    .on("meta[name^='twitter:']", rewriter)
+    .on("title", new TitleRewriter(meta.title))
+    .on("head", new HeadInjector(tags))
     .transform(response);
 }

--- a/public/index.html
+++ b/public/index.html
@@ -22,18 +22,7 @@
     <meta name="msapplication-TileImage" content="%PUBLIC_URL%/images/favicon/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
     <title>Sanket Tambare</title>
-    <meta name="description" content="Sanket Tambare's personal portfolio hub. Software engineer, marathoner, and digital curator.">
-    <meta property="og:type" content="website">
     <meta property="og:site_name" content="Sanket Tambare">
-    <meta property="og:url" content="https://daredavil.pages.dev/">
-    <meta property="og:title" content="Sanket Tambare">
-    <meta property="og:description" content="Sanket Tambare's personal portfolio hub. Software engineer, marathoner, and digital curator.">
-    <meta property="og:image" content="https://daredavil.pages.dev/images/logo.png">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Sanket Tambare">
-    <meta name="twitter:description" content="Sanket Tambare's personal portfolio hub. Software engineer, marathoner, and digital curator.">
-    <meta name="twitter:image" content="https://daredavil.pages.dev/images/logo.png">
-    <link rel="canonical" href="%PUBLIC_URL%/">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Serif:wght@700;900&family=Inter:wght@400;500;600&family=Plus_Jakarta_Sans:wght@400;500;600;700;800&family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" async>

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React, { Suspense, lazy } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { HelmetProvider } from "react-helmet-async";
 import Main from "./layouts/Main"; // fallback for lazy pages
 import "./tailwind.css"; // Tailwind globals
 import "./static/css/main.scss"; // All of our styles
@@ -26,6 +27,7 @@ const Changelog = lazy(() => import("./pages/Changelog"));
 const TreksPage = lazy(() => import("./pages/Treks"));
 
 const App = () => (
+  <HelmetProvider>
   <BrowserRouter basename={PUBLIC_URL}>
     <Suspense fallback={<Main />}>
       <Routes>
@@ -47,6 +49,7 @@ const App = () => (
       </Routes>
     </Suspense>
   </BrowserRouter>
+  </HelmetProvider>
 );
 
 export default App;

--- a/src/data/changelog.md
+++ b/src/data/changelog.md
@@ -5,6 +5,15 @@ This project does not use semantic versioning; entries are grouped by date and f
 
 ---
 
+## [v5.1.5] — 2026-04-15
+
+### Fixed
+- **App root** (`src/App.js`): Moved `HelmetProvider` from inside `Main` to the app root so all pages share a single Helmet context — previously each page mount created an isolated provider, which could cause stale/default metadata to linger between route transitions.
+- **Main layout** (`src/layouts/Main.js`): Added missing `<link rel="canonical">` tag to the Helmet block; `canonicalUrl` was already computed and used for `og:url` but was never emitted as a canonical link element, leaving search engines without a per-page canonical signal.
+- **404 page** (`src/pages/NotFound.js`): Rewrote to use the `Main` layout — previously it rendered a bare `<div>` with its own isolated `HelmetProvider`, missing site navigation, OG tags, Twitter cards, and a canonical link.
+
+---
+
 ## [v5.1.4] — 2026-04-05
 
 ### Added

--- a/src/data/changelog.md
+++ b/src/data/changelog.md
@@ -5,6 +5,13 @@ This project does not use semantic versioning; entries are grouped by date and f
 
 ---
 
+## [v5.1.7] — 2026-04-15
+
+### Fixed
+- **Cloudflare middleware** (`functions/_middleware.js`): Rewrote `HTMLRewriter` strategy from updating existing elements to appending tags into `<head>`. The previous commit removed all static OG/Twitter/canonical tags from `index.html` to prevent first-match conflicts — but the middleware was selecting those same elements to mutate them. With nothing to select, every route served identical bare metadata. The new approach uses a `HeadInjector` handler that appends the full per-route tag block to `<head>` and a `TitleRewriter` that updates the existing `<title>` element. Unknown paths now fall back to a generic `DEFAULT_META` rather than returning no metadata.
+
+---
+
 ## [v5.1.6] — 2026-04-15
 
 ### Fixed

--- a/src/data/changelog.md
+++ b/src/data/changelog.md
@@ -5,6 +5,13 @@ This project does not use semantic versioning; entries are grouped by date and f
 
 ---
 
+## [v5.1.6] — 2026-04-15
+
+### Fixed
+- **Static HTML shell** (`public/index.html`): Removed all Helmet-managed meta tags (`description`, `og:type`, `og:url`, `og:title`, `og:description`, `og:image`, `twitter:*`, `canonical`) from the static shell. The OG spec uses first-match semantics — having hardcoded homepage values appear before Helmet's `data-rh="true"` tags meant every non-root route (e.g. `/now`, `/sports`) served the wrong social metadata to any parser. Helmet now exclusively owns these tags; only `og:site_name` (static, same for all pages) and the initial `<title>` fallback remain.
+
+---
+
 ## [v5.1.5] — 2026-04-15
 
 ### Fixed

--- a/src/data/changelog.md
+++ b/src/data/changelog.md
@@ -5,6 +5,13 @@ This project does not use semantic versioning; entries are grouped by date and f
 
 ---
 
+## [v5.1.8] — 2026-04-15
+
+### Fixed
+- **Cloudflare middleware** (`functions/_middleware.js`): Removed the `Accept: text/html` request-header guard that caused the middleware to skip injection for every scraper or tool that sends `Accept: */*` (including opengraph.xyz). The response `Content-Type` check is the correct and sufficient gate; the request Accept header is unreliable for this purpose. Replaced the Accept guard with a file-extension check that skips static asset requests (`*.js`, `*.css`, `*.png`, etc.) before calling `next()`.
+
+---
+
 ## [v5.1.7] — 2026-04-15
 
 ### Fixed

--- a/src/layouts/Main.js
+++ b/src/layouts/Main.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Helmet, HelmetProvider } from "react-helmet-async";
+import { Helmet } from "react-helmet-async";
 import { useLocation } from "react-router-dom";
 
 import Navigation from "../components/Template/Navigation";
@@ -19,7 +19,7 @@ const Main = (props) => {
   const ogTitle = props.title ? `${props.title} | Sanket Tambare` : "Sanket Tambare";
 
   return (
-    <HelmetProvider>
+    <>
       <ScrollToTop />
       <Helmet
         titleTemplate="%s | Sanket Tambare"
@@ -27,6 +27,7 @@ const Main = (props) => {
         defer={false}
       >
         {props.title && <title>{props.title}</title>}
+        <link rel="canonical" href={canonicalUrl} />
         <meta name="description" content={props.description} />
         <meta property="og:type" content="website" />
         <meta property="og:url" content={canonicalUrl} />
@@ -55,7 +56,7 @@ const Main = (props) => {
         <Footer />
         <FloatingToggle />
       </div>
-    </HelmetProvider>
+    </>
   );
 };
 

--- a/src/pages/NotFound.js
+++ b/src/pages/NotFound.js
@@ -1,22 +1,32 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { Helmet, HelmetProvider } from "react-helmet-async";
+import Main from "../layouts/Main";
 
 const PageNotFound = () => (
-  <HelmetProvider>
-    <div className="not-found">
-      <Helmet title="404 Not Found">
-        <meta
-          name="description"
-          content="The content you are looking for cannot be found."
-        />
-      </Helmet>
-      <h1>Page Not Found</h1>
-      <p>
-        Return <Link to="/">home</Link>.
-      </p>
-    </div>
-  </HelmetProvider>
+  <Main
+    title="404 Not Found"
+    description="The page you are looking for cannot be found. Return to the homepage."
+  >
+    <article className="flex flex-col gap-8 w-full">
+      <header>
+        <span className="font-label text-xs uppercase tracking-[0.2em] text-secondary font-bold mb-4 block">Error 404</span>
+        <h1 className="font-headline text-5xl md:text-7xl font-black text-stone-900 dark:text-stone-100 leading-tight mb-6">
+          Page Not Found.
+        </h1>
+        <p className="font-body text-lg text-stone-500 dark:text-stone-400 max-w-xl leading-relaxed">
+          The page you&apos;re looking for doesn&apos;t exist or has been moved.
+        </p>
+      </header>
+      <div>
+        <Link
+          to="/"
+          className="inline-block px-8 py-3 border border-stone-200 dark:border-stone-700 text-stone-800 dark:text-stone-200 font-label text-[10px] uppercase tracking-widest font-bold hover:bg-stone-900 hover:text-white dark:hover:bg-stone-100 dark:hover:text-stone-950 transition-all rounded-sm no-underline"
+        >
+          Return Home
+        </Link>
+      </div>
+    </article>
+  </Main>
 );
 
 export default PageNotFound;


### PR DESCRIPTION
- Move HelmetProvider to app root (App.js) so all pages share one
  Helmet context instead of each Main mount creating an isolated one
- Add missing <link rel="canonical"> in Main.js; canonicalUrl was
  computed and used for og:url but never emitted as a canonical link
- Rewrite NotFound page to use Main layout with full OG/Twitter/
  canonical metadata; previously used a bare div with its own isolated
  HelmetProvider, bypassing site nav and all social meta tags

https://claude.ai/code/session_019KH1z9MmChZJaKYL8GqhPS