### PR TITLE
fix(lint): add .eslintignore to unblock CI builds

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,10 @@
+# Build output
+build/
+
+# Cloudflare Workers — uses CF-specific globals (HTMLRewriter, etc.) and
+# follows Workers module conventions incompatible with airbnb ESLint rules
+functions/
+
+# Tooling config files — CommonJS require() and different style conventions
+postcss.config.js
+tailwind.config.js

--- a/src/data/changelog.md
+++ b/src/data/changelog.md
@@ -5,6 +5,13 @@ This project does not use semantic versioning; entries are grouped by date and f
 
 ---
 
+## [v5.1.9] — 2026-04-15
+
+### Fixed
+- **ESLint config** (`.eslintignore`): Added ignore file to exclude `functions/` (Cloudflare Workers — uses `HTMLRewriter` and other CF globals incompatible with airbnb rules), `postcss.config.js`, and `tailwind.config.js` (CommonJS config files) from the `eslint **/*.js` sweep. These files were causing 29 lint errors and breaking the Node.js CI build on every PR.
+
+---
+
 ## [v5.1.8] — 2026-04-15
 
 ### Fixed


### PR DESCRIPTION
The Node.js CI lint step was failing with 29 ESLint errors across functions/_middleware.js (Cloudflare Workers globals + class patterns), postcss.config.js, and tailwind.config.js (CommonJS require style).

Add .eslintignore to exclude these non-React config and infrastructure files from the airbnb-rule sweep, restoring clean lint and unblocking all CI builds.