### PR TITLE
Redesign Sports and Treks cards to image-first layout

### DIFF
--- a/src/components/Sports/SportsDefault.js
+++ b/src/components/Sports/SportsDefault.js
@@ -3,6 +3,13 @@ import sportsData from '../../data/sports';
 import TopSummaryCards from './TopSummaryCards';
 import { parseDistance, parseTimeToSeconds } from './utils';
 
+const PlaceholderImage = ({ icon, label }) => (
+  <div className="w-full h-full flex flex-col items-center justify-center gap-2 bg-stone-100 dark:bg-stone-800">
+    <span className="material-symbols-outlined text-stone-300 dark:text-stone-600 text-5xl">{icon}</span>
+    <span className="font-label text-[10px] uppercase tracking-widest text-stone-400 dark:text-stone-500">{label}</span>
+  </div>
+);
+
 const SportsDefault = ({ onRaceClick }) => {
   const [filterYear, setFilterYear] = useState('all');
   const [filterPlace, setFilterPlace] = useState('all');
@@ -129,60 +136,78 @@ const SportsDefault = ({ onRaceClick }) => {
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {filtered.map((race) => {
-            const bib = race.bibNumber || 'N/A';
-            return (
-              <div
-                key={race.id}
-                className="bg-white dark:bg-stone-900 border border-secondary/20 dark:border-secondary/30 rounded-xl p-5 hover:shadow-md transition-all cursor-pointer flex flex-col"
-                onClick={() => onRaceClick(race)}
-              >
-                <div className="flex items-center justify-between mb-1">
-                  <h4 className="font-body font-bold text-blue-600 dark:text-blue-400 hover:underline">{race.title}</h4>
+          {filtered.map((race) => (
+            <div
+              key={race.id}
+              onClick={() => onRaceClick(race)}
+              className="group relative cursor-pointer rounded-xl overflow-hidden border border-stone-200 dark:border-stone-800 bg-white dark:bg-stone-900 hover:shadow-lg transition-all duration-300 flex flex-col"
+            >
+              {/* Image block */}
+              <div className="relative w-full aspect-video overflow-hidden bg-stone-100 dark:bg-stone-800">
+                {race.slideImages?.length > 0 ? (
+                  <img
+                    src={race.slideImages[0].url}
+                    alt={race.title}
+                    className="w-full h-full object-cover grayscale transition-all duration-700 group-hover:grayscale-0 group-hover:scale-105"
+                    onError={(e) => { e.currentTarget.style.display = 'none'; }}
+                  />
+                ) : (
+                  <PlaceholderImage icon="directions_run" label="No Photos Yet" />
+                )}
+                {/* Hover overlay */}
+                <div className="absolute inset-0 bg-stone-900/40 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
+                  <span className="font-label text-xs uppercase tracking-widest text-white font-bold flex items-center gap-2">
+                    <span className="material-symbols-outlined text-[18px]">photo_library</span>
+                    View Details
+                  </span>
+                </div>
+                {/* Distance badge — top-left */}
+                <div className="absolute top-3 left-3 bg-stone-900/80 backdrop-blur-sm text-white px-2.5 py-1 rounded-lg font-label text-[10px] uppercase tracking-wider font-bold">
+                  {race.distance}
+                </div>
+                {/* BIB badge — top-right */}
+                <div className="absolute top-3 right-3 bg-blue-600/90 backdrop-blur-sm text-white px-2.5 py-1 rounded-lg font-label text-[10px] font-bold">
+                  BIB {race.bibNumber || 'N/A'}
+                </div>
+              </div>
+
+              {/* Footer */}
+              <div className="p-4 flex flex-col gap-2 flex-1">
+                {/* Title + certificate link */}
+                <div className="flex items-start justify-between gap-2">
+                  <h4 className="font-body font-bold text-stone-900 dark:text-stone-100 leading-snug line-clamp-2 flex-1">
+                    {race.title}
+                  </h4>
                   <a
                     href={race.timeCertificateLink}
                     target="_blank"
                     rel="noopener noreferrer"
                     onClick={(e) => e.stopPropagation()}
-                    className="p-1 hover:bg-stone-100 dark:hover:bg-stone-800 rounded transition-colors text-blue-500"
+                    className="shrink-0 p-1 hover:bg-stone-100 dark:hover:bg-stone-800 rounded transition-colors text-blue-500"
+                    title="View certificate"
                   >
                     <span className="material-symbols-outlined text-[16px]">open_in_new</span>
                   </a>
                 </div>
-
-                <p className="text-xs text-stone-500 dark:text-stone-400 italic mb-4 line-clamp-1">
-                  {race.description}
-                </p>
-
-                <div className="flex flex-col gap-2 mb-4 text-xs font-label">
-                  <div className="flex items-center gap-2 text-stone-600 dark:text-stone-300">
-                    <span className="material-symbols-outlined text-[14px]">calendar_today</span>
+                {/* Date + Place */}
+                <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs font-label text-stone-500 dark:text-stone-400">
+                  <span className="flex items-center gap-1">
+                    <span className="material-symbols-outlined text-[13px]">calendar_today</span>
                     {race.date}
-                  </div>
-                  <div className="flex items-center gap-2 text-stone-600 dark:text-stone-300">
-                    <span className="material-symbols-outlined text-[14px]">location_on</span>
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <span className="material-symbols-outlined text-[13px]">location_on</span>
                     {race.place}
-                  </div>
+                  </span>
                 </div>
-
-                <div className="inline-flex max-w-min items-center gap-1 bg-blue-600 text-white rounded px-2 py-0.5 mt-auto mb-4">
-                  <span className="font-label text-[10px] font-bold">BIB:</span>
-                  <span className="font-label text-xs font-bold">{bib}</span>
-                </div>
-
-                <div className="flex items-center justify-between border-t border-stone-100 dark:border-stone-800 pt-3">
-                  <div className="flex items-center gap-1 font-label text-xs text-stone-800 dark:text-stone-200">
-                    <span className="material-symbols-outlined text-yellow-500 text-[16px]">emoji_events</span>
-                    {race.distance}
-                  </div>
-                  <div className="flex items-center gap-1 font-label font-bold text-xs text-stone-800 dark:text-stone-200">
-                    <span className="material-symbols-outlined text-[16px]">schedule</span>
-                    {race.time}
-                  </div>
+                {/* Finish time */}
+                <div className="flex items-center gap-1 font-label font-bold text-sm text-stone-800 dark:text-stone-200 border-t border-stone-100 dark:border-stone-800 pt-2 mt-auto">
+                  <span className="material-symbols-outlined text-yellow-500 text-[16px]">schedule</span>
+                  {race.time}
                 </div>
               </div>
-            );
-          })}
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/src/components/Sports/SportsInteractive.js
+++ b/src/components/Sports/SportsInteractive.js
@@ -3,10 +3,17 @@ import sportsData from '../../data/sports';
 import { parseDistance } from './utils';
 import TopSummaryCards from './TopSummaryCards';
 
+const PlaceholderImage = ({ icon, label }) => (
+  <div className="w-full h-full flex flex-col items-center justify-center gap-2 bg-stone-100 dark:bg-stone-800">
+    <span className="material-symbols-outlined text-stone-300 dark:text-stone-600 text-5xl">{icon}</span>
+    <span className="font-label text-[10px] uppercase tracking-widest text-stone-400 dark:text-stone-500">{label}</span>
+  </div>
+);
+
 const SportsInteractive = ({ onRaceClick }) => {
   const groupedData = useMemo(() => {
     const grouped = {};
-    
+
     sportsData.forEach((race) => {
       const d = parseDistance(race.distance);
       if (d > 0) {
@@ -27,7 +34,6 @@ const SportsInteractive = ({ onRaceClick }) => {
       });
     });
 
-    // Only return groups that have races, sorted by distance desc
     return Object.entries(grouped)
       .filter(([, list]) => list.length > 0)
       .sort((a, b) => parseInt(b[0], 10) - parseInt(a[0], 10));
@@ -45,21 +51,50 @@ const SportsInteractive = ({ onRaceClick }) => {
           </h3>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {races.map((race) => {
-              const bib = race.bibNumber || "N/A";
-
+              const bib = race.bibNumber || 'N/A';
               return (
-                <div 
-                  key={race.id} 
-                  className="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-800 rounded-xl overflow-hidden hover:shadow-lg transition-all cursor-pointer flex flex-col"
+                <div
+                  key={race.id}
                   onClick={() => onRaceClick(race)}
+                  className="group relative cursor-pointer rounded-xl overflow-hidden border border-stone-200 dark:border-stone-800 bg-white dark:bg-stone-900 hover:shadow-lg transition-all duration-300 flex flex-col"
                 >
-                  <div className="p-5 flex-1">
-                    <h4 className="font-body font-bold text-stone-900 dark:text-stone-100 mb-1">{race.title}</h4>
-                    <div className="font-label text-[10px] text-stone-400 dark:text-stone-500 uppercase tracking-widest mb-4">
-                      {race.date}
+                  {/* Image block */}
+                  <div className="relative w-full aspect-video overflow-hidden bg-stone-100 dark:bg-stone-800">
+                    {race.slideImages?.length > 0 ? (
+                      <img
+                        src={race.slideImages[0].url}
+                        alt={race.title}
+                        className="w-full h-full object-cover grayscale transition-all duration-700 group-hover:grayscale-0 group-hover:scale-105"
+                        onError={(e) => { e.currentTarget.style.display = 'none'; }}
+                      />
+                    ) : (
+                      <PlaceholderImage icon="directions_run" label="No Photos Yet" />
+                    )}
+                    {/* Hover overlay */}
+                    <div className="absolute inset-0 bg-stone-900/40 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
+                      <span className="font-label text-xs uppercase tracking-widest text-white font-bold flex items-center gap-2">
+                        <span className="material-symbols-outlined text-[18px]">photo_library</span>
+                        View Details
+                      </span>
                     </div>
-                    
-                    <div className="flex justify-between items-end mt-4">
+                    {/* BIB badge — top-right */}
+                    <div className="absolute top-3 right-3 bg-blue-600/90 backdrop-blur-sm text-white px-2.5 py-1 rounded-lg font-label text-[10px] font-bold">
+                      BIB {bib}
+                    </div>
+                  </div>
+
+                  {/* Footer */}
+                  <div className="p-4 flex flex-col gap-3 flex-1">
+                    <div>
+                      <h4 className="font-body font-bold text-stone-900 dark:text-stone-100 leading-snug line-clamp-2">
+                        {race.title}
+                      </h4>
+                      <div className="font-label text-[10px] text-stone-400 dark:text-stone-500 uppercase tracking-widest mt-1">
+                        {race.date}
+                      </div>
+                    </div>
+
+                    <div className="flex justify-between items-end border-t border-stone-100 dark:border-stone-800 pt-3 mt-auto">
                       <div>
                         <div className="font-label text-[10px] text-stone-400 dark:text-stone-500 uppercase tracking-widest">Place</div>
                         <div className="text-sm text-stone-800 dark:text-stone-200">{race.place}</div>
@@ -73,16 +108,6 @@ const SportsInteractive = ({ onRaceClick }) => {
                         <div className="text-sm text-stone-800 dark:text-stone-200">{race.distance}</div>
                       </div>
                     </div>
-                  </div>
-                  
-                  <div className="p-4 bg-stone-50 dark:bg-stone-800/50 border-t border-stone-100 dark:border-stone-800">
-                    <div className="bg-blue-600 text-white rounded-lg p-3 flex justify-between items-center mb-3">
-                      <span className="font-label font-bold text-xs uppercase tracking-widest">BIB NUMBER</span>
-                      <span className="font-headline text-lg">{bib}</span>
-                    </div>
-                    <button className="w-full py-2 text-center text-xs font-label uppercase tracking-widest font-bold text-stone-500 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-100 transition-colors">
-                      Show Details
-                    </button>
                   </div>
                 </div>
               );

--- a/src/components/Treks/TreksDefault.js
+++ b/src/components/Treks/TreksDefault.js
@@ -25,14 +25,21 @@ const parseTrekTimeToMinutes = (timeStr) => {
   return 0;
 };
 
-const difficultyBadgeClass = (level) => {
+const difficultyOverlayClass = (level) => {
   switch (level?.toLowerCase()) {
-    case 'easy': return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400';
-    case 'medium': return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400';
-    case 'hard': return 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400';
-    default: return 'bg-stone-100 text-stone-700 dark:bg-stone-800 dark:text-stone-400';
+    case 'easy': return 'bg-green-700/80 text-green-100';
+    case 'medium': return 'bg-yellow-700/80 text-yellow-100';
+    case 'hard': return 'bg-red-700/80 text-red-100';
+    default: return 'bg-stone-700/80 text-stone-200';
   }
 };
+
+const PlaceholderImage = ({ icon, label }) => (
+  <div className="w-full h-full flex flex-col items-center justify-center gap-2 bg-stone-100 dark:bg-stone-800">
+    <span className="material-symbols-outlined text-stone-300 dark:text-stone-600 text-5xl">{icon}</span>
+    <span className="font-label text-[10px] uppercase tracking-widest text-stone-400 dark:text-stone-500">{label}</span>
+  </div>
+);
 
 const TreksDefault = ({ onTrekClick }) => {
   const [filterDifficulty, setFilterDifficulty] = useState('all');
@@ -156,48 +163,70 @@ const TreksDefault = ({ onTrekClick }) => {
           {filtered.map((trek) => (
             <div
               key={trek.id}
-              className="bg-white dark:bg-stone-900 border border-secondary/20 dark:border-secondary/30 rounded-xl p-5 hover:shadow-md transition-all cursor-pointer flex flex-col"
               onClick={() => onTrekClick(trek)}
+              className="group relative cursor-pointer rounded-xl overflow-hidden border border-stone-200 dark:border-stone-800 bg-white dark:bg-stone-900 hover:shadow-lg transition-all duration-300 flex flex-col"
             >
-              <div className="flex items-start justify-between mb-3 gap-2">
-                <h4 className="font-body font-bold text-stone-900 dark:text-stone-100 leading-snug flex-1">
+              {/* Image block */}
+              <div className="relative w-full aspect-[4/3] overflow-hidden bg-stone-100 dark:bg-stone-800">
+                {trek.photos?.length > 0 ? (
+                  <img
+                    src={trek.photos[0].url}
+                    alt={trek.fort_name}
+                    className="w-full h-full object-cover grayscale transition-all duration-700 group-hover:grayscale-0 group-hover:scale-105"
+                    onError={(e) => { e.currentTarget.style.display = 'none'; }}
+                  />
+                ) : (
+                  <PlaceholderImage icon="terrain" label="No Photos Yet" />
+                )}
+                {/* Hover overlay */}
+                <div className="absolute inset-0 bg-stone-900/40 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
+                  <span className="font-label text-xs uppercase tracking-widest text-white font-bold flex items-center gap-2">
+                    <span className="material-symbols-outlined text-[18px]">photo_library</span>
+                    View Trek
+                  </span>
+                </div>
+                {/* Difficulty badge — top-left */}
+                <div className={`absolute top-3 left-3 px-2.5 py-1 rounded-lg font-label text-[10px] uppercase tracking-wider font-bold backdrop-blur-sm ${difficultyOverlayClass(trek.endurance_level)}`}>
+                  {trek.endurance_level}
+                </div>
+                {/* Photo count badge — top-right */}
+                <div className="absolute top-3 right-3 bg-stone-900/70 backdrop-blur-sm text-white px-2 py-1 rounded-lg font-label text-[10px] font-bold flex items-center gap-1">
+                  <span className="material-symbols-outlined text-[12px]">photo_library</span>
+                  {trek.photos?.length || 0}
+                </div>
+              </div>
+
+              {/* Footer */}
+              <div className="p-4 flex flex-col gap-2 flex-1">
+                <h4 className="font-body font-bold text-stone-900 dark:text-stone-100 leading-snug line-clamp-2">
                   {trek.fort_name}
                 </h4>
-                <span className={`shrink-0 px-2 py-0.5 rounded-full text-[10px] font-label font-bold uppercase tracking-widest ${difficultyBadgeClass(trek.endurance_level)}`}>
-                  {trek.endurance_level}
-                </span>
-              </div>
-
-              <div className="flex flex-col gap-2 mb-4 text-xs font-label flex-1">
-                <div className="flex items-center gap-2 text-stone-600 dark:text-stone-300">
-                  <span className="material-symbols-outlined text-[14px]">calendar_today</span>
-                  {trek.date}
+                <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs font-label text-stone-500 dark:text-stone-400">
+                  <span className="flex items-center gap-1">
+                    <span className="material-symbols-outlined text-[13px]">calendar_today</span>
+                    {trek.date}
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <span className="material-symbols-outlined text-[13px]">schedule</span>
+                    {trek.trek_time}
+                  </span>
                 </div>
-                <div className="flex items-center gap-2 text-stone-600 dark:text-stone-300">
-                  <span className="material-symbols-outlined text-[14px]">schedule</span>
-                  {trek.trek_time}
+                <div className="border-t border-stone-100 dark:border-stone-800 pt-2 mt-auto">
+                  {trek.blog_link ? (
+                    <a
+                      href={trek.blog_link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={(e) => e.stopPropagation()}
+                      className="flex items-center gap-1 text-indigo-600 dark:text-indigo-400 hover:underline text-xs font-label font-bold w-fit"
+                    >
+                      <span className="material-symbols-outlined text-[14px]">article</span>
+                      Read Blog
+                    </a>
+                  ) : (
+                    <span className="text-stone-300 dark:text-stone-600 text-xs font-label">No blog</span>
+                  )}
                 </div>
-              </div>
-
-              <div className="flex items-center justify-between border-t border-stone-100 dark:border-stone-800 pt-3 mt-auto">
-                <div className="flex items-center gap-1 text-stone-400 dark:text-stone-500 text-xs font-label">
-                  <span className="material-symbols-outlined text-[14px]">photo_library</span>
-                  {trek.photos?.length || 0} photos
-                </div>
-                {trek.blog_link ? (
-                  <a
-                    href={trek.blog_link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={(e) => e.stopPropagation()}
-                    className="flex items-center gap-1 text-indigo-600 dark:text-indigo-400 hover:underline text-xs font-label font-bold"
-                  >
-                    <span className="material-symbols-outlined text-[14px]">article</span>
-                    Read Blog
-                  </a>
-                ) : (
-                  <span className="text-stone-300 dark:text-stone-600 text-xs font-label">No blog</span>
-                )}
               </div>
             </div>
           ))}

--- a/src/data/changelog.md
+++ b/src/data/changelog.md
@@ -5,6 +5,15 @@ This project does not use semantic versioning; entries are grouped by date and f
 
 ---
 
+## [v6.1.0] — 2026-04-21
+
+### Changed
+- **SportsDefault** (`src/components/Sports/SportsDefault.js`): Redesigned DEFAULT VIEW cards to image-first. Cards now lead with the first `slideImages` entry in a 16:9 container with grayscale-to-color hover transition and overlay. Distance and BIB promoted to image corner badges; footer retains title, date, place, and finish time.
+- **TreksDefault** (`src/components/Treks/TreksDefault.js`): Redesigned DEFAULT VIEW cards to image-first. Cards lead with the first `photos` entry in a 4:3 container with same hover effect. Difficulty and photo count promoted to image corner badges; footer retains fort name, date, trek time, and blog link. Placeholder shown for entries with no images.
+- **SportsInteractive** (`src/components/Sports/SportsInteractive.js`): Redesigned INTERACTIVE VIEW cards to image-first. Cards now lead with the first `slideImages` entry using the same grayscale hover pattern. BIB badge overlaid on image; footer retains title, date, and place/time/distance stats row.
+
+---
+
 ## [v6.0.0] — 2026-04-17
 
 ### Added


### PR DESCRIPTION
## Summary
- **SportsDefault**: Cards now lead with race photo (16:9), grayscale-to-color hover, Distance + BIB corner badges, compact footer with title/date/place/time
- **TreksDefault**: Cards lead with fort photo (4:3), difficulty + photo-count corner badges, compact footer with name/date/trek-time/blog link
- **SportsInteractive**: Same image-first treatment; BIB badge overlaid on image; distance badge omitted (cards already grouped by distance section headers)

## Test plan
- [ ] Sports DEFAULT VIEW — cards show photos, hover grayscale → color with "View Details" overlay
- [ ] Sports INTERACTIVE VIEW — cards show photos, BIB badge on image, section headers unchanged
- [ ] Treks DEFAULT VIEW — cards show fort photos, difficulty badge (green/yellow/red), photo count badge
- [ ] Card click opens modal with full details
- [ ] Certificate/blog links fire without opening modal (`stopPropagation`)
- [ ] Filter/sort controls still work on both pages
- [ ] Dark mode renders correctly
- [ ] Responsive: 1-col mobile, 2-col tablet, 3-col desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)