### PR TITLE
Fix accessibility, design consistency, and UX gaps

### DIFF
--- a/src/components/Books/DigitalLibrary.js
+++ b/src/components/Books/DigitalLibrary.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect, useRef } from 'react';
 
 const BookCard = ({ book, onClick }) => (
   <div className="group cursor-pointer border border-transparent flex flex-col h-full" onClick={onClick}>
@@ -30,11 +30,19 @@ const BookCard = ({ book, onClick }) => (
 );
 
 const DigitalLibrary = ({ books }) => {
+  const [searchInput, setSearchInput] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
+  const debounceRef = useRef(null);
   const [filter, setFilter] = useState('All');
   const [filterLanguage, setFilterLanguage] = useState('All');
   const [filterReview, setFilterReview] = useState('All');
   const [selectedBook, setSelectedBook] = useState(null);
+
+  useEffect(() => {
+    clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => setSearchTerm(searchInput), 300);
+    return () => clearTimeout(debounceRef.current);
+  }, [searchInput]);
 
   // Get unique tags and languages
   const allTags = useMemo(() => {
@@ -162,8 +170,8 @@ const DigitalLibrary = ({ books }) => {
               <input 
                 type="text" 
                 placeholder="Search titles or authors..." 
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
                 className="w-full h-12 bg-white dark:bg-stone-900 border border-stone-100 dark:border-stone-800 rounded-lg px-10 font-body text-sm text-stone-950 dark:text-stone-100 placeholder:text-stone-400 dark:placeholder:text-stone-600 outline-none focus:border-secondary transition-colors"
               />
               <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-stone-400 dark:text-stone-600 pointer-events-none text-[18px]">search</span>
@@ -209,9 +217,10 @@ const DigitalLibrary = ({ books }) => {
 
           {/* Clear Filters Button */}
           <div className="flex justify-end mb-8 -mt-4 h-8 px-2">
-            {(searchTerm !== "" || filter !== "All" || filterLanguage !== "All" || filterReview !== "All") && (
-              <button 
+            {(searchInput !== "" || filter !== "All" || filterLanguage !== "All" || filterReview !== "All") && (
+              <button
                 onClick={() => {
+                  setSearchInput("");
                   setSearchTerm("");
                   setFilter("All");
                   setFilterLanguage("All");
@@ -228,7 +237,7 @@ const DigitalLibrary = ({ books }) => {
       </section>
 
       {/* Library Grid */}
-      <section className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-y-16 gap-x-8 w-full relative z-0">
+      <section className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-y-8 gap-x-8 w-full relative z-0">
         {filteredBooks.length > 0 ? filteredBooks.map((book) => (
           <BookCard 
             key={book.id} 

--- a/src/components/Index/LifeStats.js
+++ b/src/components/Index/LifeStats.js
@@ -129,11 +129,17 @@ const LifeStats = () => {
                 className="font-headline font-black text-stone-900 dark:text-stone-100 leading-none tracking-tighter"
                 style={{ fontSize: "clamp(2rem, 4vw, 3rem)" }}
               >
-                {stat.value.toLocaleString()}
-                {stat.suffix && (
-                  <span className="text-xl font-bold text-stone-400 dark:text-stone-500 ml-1">
-                    {stat.suffix}
-                  </span>
+                {animated ? (
+                  <>
+                    {stat.value.toLocaleString()}
+                    {stat.suffix && (
+                      <span className="text-xl font-bold text-stone-400 dark:text-stone-500 ml-1">
+                        {stat.suffix}
+                      </span>
+                    )}
+                  </>
+                ) : (
+                  <span className="text-stone-300 dark:text-stone-700">—</span>
                 )}
               </div>
               <p className="font-headline font-bold text-stone-700 dark:text-stone-300 text-sm mt-1 uppercase tracking-wider">

--- a/src/components/Projects/ProjectGallery.js
+++ b/src/components/Projects/ProjectGallery.js
@@ -1,4 +1,16 @@
-import React from 'react';
+import React, { useState } from 'react';
+
+const ImageWithFallback = ({ src, alt, className }) => {
+  const [errored, setErrored] = useState(false);
+  if (errored) {
+    return (
+      <div className="absolute inset-0 flex items-center justify-center">
+        <span className="material-symbols-outlined text-stone-300 dark:text-stone-600 text-5xl">broken_image</span>
+      </div>
+    );
+  }
+  return <img src={src} alt={alt} className={className} onError={() => setErrored(true)} />;
+};
 
 const ProjectGallery = ({ projects }) => {
   return (
@@ -10,11 +22,10 @@ const ProjectGallery = ({ projects }) => {
           return (
             <section key={index} className="col-span-12 md:col-span-8 group mt-8 md:mt-0">
               <div className="overflow-hidden rounded-lg mb-6 bg-stone-100 dark:bg-stone-900 border border-stone-200 dark:border-stone-800 aspect-video relative">
-                <img 
-                  alt={project.title} 
-                  className="w-full h-full object-cover grayscale transition-all duration-700 group-hover:grayscale-0 group-hover:scale-105" 
+                <ImageWithFallback
+                  alt={project.title}
+                  className="w-full h-full object-cover grayscale transition-all duration-700 group-hover:grayscale-0 group-hover:scale-105"
                   src={project.image}
-                  onError={(e) => { e.target.style.display = 'none'; }}
                 />
                 <div className="absolute top-6 right-6">
                   <span className="bg-stone-900/90 dark:bg-stone-950/90 backdrop-blur px-3 py-1 font-label text-[10px] uppercase tracking-tighter text-white border border-stone-700 dark:border-stone-800">Case Study 0{index + 1}</span>
@@ -40,11 +51,10 @@ const ProjectGallery = ({ projects }) => {
           return (
             <section key={index} className="col-span-12 md:col-span-4 mt-0 md:mt-24 group">
               <div className="overflow-hidden rounded-lg mb-6 bg-stone-100 dark:bg-stone-900 border border-stone-200 dark:border-stone-800 aspect-[3/4] relative">
-                <img 
-                  alt={project.title} 
-                  className="w-full h-full object-cover grayscale transition-all duration-700 group-hover:grayscale-0 group-hover:scale-105" 
+                <ImageWithFallback
+                  alt={project.title}
+                  className="w-full h-full object-cover grayscale transition-all duration-700 group-hover:grayscale-0 group-hover:scale-105"
                   src={project.image}
-                  onError={(e) => { e.target.style.display = 'none'; }}
                 />
               </div>
               <div className="pr-4">
@@ -85,11 +95,10 @@ const ProjectGallery = ({ projects }) => {
           return (
             <section key={index} className="col-span-12 md:col-span-7 group mt-4 md:mt-0">
               <div className="overflow-hidden rounded-lg mb-6 bg-stone-100 dark:bg-stone-900 border border-stone-200 dark:border-stone-800 aspect-[16/10] relative">
-                <img 
-                  alt={project.title} 
-                  className="w-full h-full object-cover grayscale transition-all duration-700 group-hover:grayscale-0 group-hover:scale-105" 
+                <ImageWithFallback
+                  alt={project.title}
+                  className="w-full h-full object-cover grayscale transition-all duration-700 group-hover:grayscale-0 group-hover:scale-105"
                   src={project.image}
-                  onError={(e) => { e.target.style.display = 'none'; }}
                 />
               </div>
               <div className="flex justify-between items-start">
@@ -108,11 +117,10 @@ const ProjectGallery = ({ projects }) => {
           return (
             <section key={index} className="col-span-12 md:col-span-4 group mt-4 md:mt-0">
               <div className="overflow-hidden rounded-lg mb-6 bg-stone-100 dark:bg-stone-900 border border-stone-200 dark:border-stone-800 aspect-[4/5] relative">
-                <img 
-                  alt={project.title} 
-                  className="w-full h-full object-cover grayscale transition-all duration-700 group-hover:grayscale-0 group-hover:scale-105" 
+                <ImageWithFallback
+                  alt={project.title}
+                  className="w-full h-full object-cover grayscale transition-all duration-700 group-hover:grayscale-0 group-hover:scale-105"
                   src={project.image}
-                  onError={(e) => { e.target.style.display = 'none'; }}
                 />
               </div>
               <h2 className="font-headline text-xl font-bold mb-2 text-stone-800 dark:text-stone-100">{project.title}</h2>
@@ -136,11 +144,10 @@ const ProjectGallery = ({ projects }) => {
                 )}
               </div>
               <div className="flex-1 order-1 md:order-2 overflow-hidden rounded-lg bg-stone-100 dark:bg-stone-900 border border-stone-200 dark:border-stone-800 aspect-square relative group w-full">
-                <img 
-                  alt={project.title} 
-                  className="w-full h-full object-cover grayscale transition-all duration-700 group-hover:grayscale-0 group-hover:scale-105" 
+                <ImageWithFallback
+                  alt={project.title}
+                  className="w-full h-full object-cover grayscale transition-all duration-700 group-hover:grayscale-0 group-hover:scale-105"
                   src={project.image}
-                  onError={(e) => { e.target.style.display = 'none'; }}
                 />
               </div>
             </section>

--- a/src/components/Sports/SportsStatistics.js
+++ b/src/components/Sports/SportsStatistics.js
@@ -92,22 +92,22 @@ const SportsStatistics = () => {
 
       {/* Sub-summary cards */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-2">
-        <div className="bg-orange-50 dark:bg-orange-900/10 border border-orange-200 dark:border-orange-800/40 p-4 rounded-xl text-center flex flex-col items-center justify-center">
-          <div className="font-headline text-2xl text-orange-600 dark:text-orange-400">{mostActiveCity.name}</div>
+        <div className="bg-amber-50 dark:bg-amber-900/10 border border-amber-200 dark:border-amber-800/40 p-4 rounded-xl text-center flex flex-col items-center justify-center">
+          <div className="font-headline text-2xl text-amber-600 dark:text-amber-400">{mostActiveCity.name}</div>
           <div className="font-label text-[10px] text-stone-500 dark:text-stone-400 uppercase tracking-widest mt-1">Most Active City</div>
           <div className="text-xs text-stone-400 dark:text-stone-500 mt-1">{mostActiveCity.count} races</div>
         </div>
-        <div className="bg-pink-50 dark:bg-pink-900/10 border border-pink-200 dark:border-pink-800/40 p-4 rounded-xl text-center flex flex-col items-center justify-center">
-          <div className="font-headline text-2xl text-pink-600 dark:text-pink-400">{mostActiveYear.year}</div>
+        <div className="bg-red-50 dark:bg-red-900/10 border border-red-200 dark:border-red-800/40 p-4 rounded-xl text-center flex flex-col items-center justify-center">
+          <div className="font-headline text-2xl text-red-600 dark:text-red-400">{mostActiveYear.year}</div>
           <div className="font-label text-[10px] text-stone-500 dark:text-stone-400 uppercase tracking-widest mt-1">Most Active Year</div>
           <div className="text-xs text-stone-400 dark:text-stone-500 mt-1">{mostActiveYear.count} races</div>
         </div>
-        <div className="bg-indigo-50 dark:bg-indigo-900/10 border border-indigo-200 dark:border-indigo-800/40 p-4 rounded-xl text-center flex flex-col items-center justify-center">
-          <div className="font-headline text-3xl text-indigo-600 dark:text-indigo-400">{citiesVisited}</div>
+        <div className="bg-secondary/[0.04] dark:bg-secondary/[0.08] border border-secondary/20 dark:border-secondary/30 p-4 rounded-xl text-center flex flex-col items-center justify-center">
+          <div className="font-headline text-3xl text-secondary">{citiesVisited}</div>
           <div className="font-label text-[10px] text-stone-500 dark:text-stone-400 uppercase tracking-widest mt-1">Cities Visited</div>
         </div>
-        <div className="bg-teal-50 dark:bg-teal-900/10 border border-teal-200 dark:border-teal-800/40 p-4 rounded-xl text-center flex flex-col items-center justify-center">
-          <div className="font-headline text-3xl text-teal-600 dark:text-teal-400">{yearsActive}</div>
+        <div className="bg-stone-50 dark:bg-stone-800/30 border border-stone-200 dark:border-stone-700/40 p-4 rounded-xl text-center flex flex-col items-center justify-center">
+          <div className="font-headline text-3xl text-stone-700 dark:text-stone-300">{yearsActive}</div>
           <div className="font-label text-[10px] text-stone-500 dark:text-stone-400 uppercase tracking-widest mt-1">Years Active</div>
         </div>
       </div>
@@ -129,7 +129,7 @@ const SportsStatistics = () => {
                   <span className="text-stone-500 dark:text-stone-400">{count} races ({pct}%)</span>
                 </div>
                 <div className="w-full bg-stone-100 dark:bg-stone-800 rounded-full h-1.5 overflow-hidden">
-                  <div className="bg-gradient-to-r from-purple-500 to-indigo-500 h-1.5 rounded-full" style={{ width: `${pct}%` }}></div>
+                  <div className="bg-secondary h-1.5 rounded-full" style={{ width: `${pct}%` }}></div>
                 </div>
               </div>
             );
@@ -150,7 +150,7 @@ const SportsStatistics = () => {
             return (
               <div key={d} className="border border-stone-200 dark:border-stone-800 rounded-xl p-4 flex justify-between">
                 <div>
-                  <div className="font-label text-blue-600 dark:text-blue-400 text-sm mb-2">{d} km</div>
+                  <div className="font-label text-secondary text-sm mb-2">{d} km</div>
                   <div className="font-headline text-3xl text-stone-900 dark:text-stone-100 mb-1">{best.race.time}</div>
                   <div className="text-xs text-stone-500 dark:text-stone-400 font-label">{best.race.title}</div>
                   <div className="text-[10px] text-stone-400 dark:text-stone-500 mt-0.5">{best.race.date}</div>
@@ -176,7 +176,7 @@ const SportsStatistics = () => {
             return (
               <div key={d} className="border border-stone-200 dark:border-stone-800 rounded-xl p-4 text-center">
                 <div className="font-label text-stone-500 dark:text-stone-400 text-xs mb-2">{d} km</div>
-                <div className="font-headline text-2xl text-green-600 dark:text-green-500 mb-1">{pace}</div>
+                <div className="font-headline text-2xl text-secondary mb-1">{pace}</div>
                 <div className="text-[10px] text-stone-400 dark:text-stone-500">min/km</div>
               </div>
             );
@@ -197,7 +197,7 @@ const SportsStatistics = () => {
                 <span className="material-symbols-outlined text-[16px] text-stone-400">location_on</span>
                 {city.name}
               </span>
-              <span className="text-orange-600 dark:text-orange-500 font-bold">{city.count}</span>
+              <span className="text-secondary font-bold">{city.count}</span>
             </div>
           ))}
         </div>
@@ -220,7 +220,7 @@ const SportsStatistics = () => {
                   <span className="text-stone-500 dark:text-stone-400">{year.count} races</span>
                 </div>
                 <div className="w-full bg-stone-100 dark:bg-stone-800 rounded-full h-1.5 overflow-hidden">
-                  <div className="bg-pink-500 h-1.5 rounded-full" style={{ width: `${pct}%` }}></div>
+                  <div className="bg-red-400 h-1.5 rounded-full" style={{ width: `${pct}%` }}></div>
                 </div>
               </div>
             );

--- a/src/components/Sports/TopSummaryCards.js
+++ b/src/components/Sports/TopSummaryCards.js
@@ -18,16 +18,16 @@ const TopSummaryCards = () => {
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8 w-full">
-      <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-100 dark:border-blue-800/50 p-6 rounded-xl text-center">
-        <div className="font-headline text-5xl text-blue-600 dark:text-blue-400 mb-2">{totalRaces}</div>
+      <div className="bg-red-50 dark:bg-red-900/20 border border-red-100 dark:border-red-800/50 p-6 rounded-xl text-center">
+        <div className="font-headline text-5xl text-red-600 dark:text-red-400 mb-2">{totalRaces}</div>
         <div className="font-label text-xs text-stone-500 dark:text-stone-400 uppercase tracking-widest">Total Races</div>
       </div>
-      <div className="bg-purple-50 dark:bg-purple-900/20 border border-purple-100 dark:border-purple-800/50 p-6 rounded-xl text-center">
-        <div className="font-headline text-5xl text-purple-600 dark:text-purple-400 mb-2">{totalDistance.toFixed(1)}K</div>
+      <div className="bg-secondary/[0.04] dark:bg-secondary/[0.08] border border-secondary/20 dark:border-secondary/30 p-6 rounded-xl text-center">
+        <div className="font-headline text-5xl text-secondary mb-2">{totalDistance.toFixed(1)}K</div>
         <div className="font-label text-xs text-stone-500 dark:text-stone-400 uppercase tracking-widest">Total Distance</div>
       </div>
-      <div className="bg-green-50 dark:bg-green-900/20 border border-green-100 dark:border-green-800/50 p-6 rounded-xl text-center">
-        <div className="font-headline text-5xl text-green-600 dark:text-green-400 mb-2">{avgPerRace}</div>
+      <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-100 dark:border-amber-800/50 p-6 rounded-xl text-center">
+        <div className="font-headline text-5xl text-amber-600 dark:text-amber-400 mb-2">{avgPerRace}</div>
         <div className="font-label text-xs text-stone-500 dark:text-stone-400 uppercase tracking-widest">Avg Per Race (km)</div>
       </div>
     </div>

--- a/src/components/Template/Footer.js
+++ b/src/components/Template/Footer.js
@@ -3,14 +3,14 @@ import React from 'react';
 const Footer = () => (
   <footer className="w-full border-t border-stone-200/40 dark:border-stone-800/40 bg-stone-100 dark:bg-stone-900">
     <div className="flex flex-col md:flex-row justify-between items-center px-8 py-12 gap-6 max-w-7xl mx-auto">
-      <div className="font-label text-xs uppercase tracking-widest text-stone-500 dark:text-stone-400">
+      <div className="font-label text-xs uppercase tracking-widest text-stone-600 dark:text-stone-400">
         © {new Date().getFullYear()} sanket tambare. Built with intentionality.
       </div>
       <div className="flex gap-8">
-        <a href="mailto:contact@sankettambare.com" className="font-label text-xs uppercase tracking-widest text-stone-500 dark:text-stone-400 hover:text-orange-700 dark:hover:text-orange-600 transition-colors hover:underline decoration-orange-700 underline-offset-4">Mail</a>
-        <a href="https://github.com/daredavil01" target="_blank" rel="noopener noreferrer" className="font-label text-xs uppercase tracking-widest text-stone-500 dark:text-stone-400 hover:text-orange-700 dark:hover:text-orange-600 transition-colors hover:underline decoration-orange-700 underline-offset-4">GitHub</a>
-        <a href="https://linkedin.com/in/sankettambare" target="_blank" rel="noopener noreferrer" className="font-label text-xs uppercase tracking-widest text-stone-500 dark:text-stone-400 hover:text-orange-700 dark:hover:text-orange-600 transition-colors hover:underline decoration-orange-700 underline-offset-4">LinkedIn</a>
-        <a href="https://instagram.com/sanket.tambare" target="_blank" rel="noopener noreferrer" className="font-label text-xs uppercase tracking-widest text-stone-500 dark:text-stone-400 hover:text-orange-700 dark:hover:text-orange-600 transition-colors hover:underline decoration-orange-700 underline-offset-4">Instagram</a>
+        <a href="mailto:contact@sankettambare.com" className="font-label text-xs uppercase tracking-widest text-stone-600 dark:text-stone-400 hover:text-secondary dark:hover:text-secondary transition-colors hover:underline decoration-secondary underline-offset-4">Mail</a>
+        <a href="https://github.com/daredavil01" target="_blank" rel="noopener noreferrer" className="font-label text-xs uppercase tracking-widest text-stone-600 dark:text-stone-400 hover:text-secondary dark:hover:text-secondary transition-colors hover:underline decoration-secondary underline-offset-4">GitHub</a>
+        <a href="https://linkedin.com/in/sankettambare" target="_blank" rel="noopener noreferrer" className="font-label text-xs uppercase tracking-widest text-stone-600 dark:text-stone-400 hover:text-secondary dark:hover:text-secondary transition-colors hover:underline decoration-secondary underline-offset-4">LinkedIn</a>
+        <a href="https://instagram.com/sanket.tambare" target="_blank" rel="noopener noreferrer" className="font-label text-xs uppercase tracking-widest text-stone-600 dark:text-stone-400 hover:text-secondary dark:hover:text-secondary transition-colors hover:underline decoration-secondary underline-offset-4">Instagram</a>
       </div>
     </div>
   </footer>

--- a/src/components/Template/Hamburger.js
+++ b/src/components/Template/Hamburger.js
@@ -1,7 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { Link, useLocation } from 'react-router-dom';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import routes from '../../data/routes';
+import contactData from '../../data/contact';
 
 const Hamburger = () => {
   const [open, setOpen] = useState(false);
@@ -46,7 +48,7 @@ const Hamburger = () => {
         </div>
 
         {/* Nav links */}
-        <nav className="flex flex-col px-4 py-4 gap-0.5">
+        <nav className="flex flex-col px-4 py-4 gap-0.5 flex-grow">
           {allRoutes.map((l) => {
             const isActive = location.pathname === l.path
               || (location.pathname.startsWith(l.path) && l.path !== '/');
@@ -87,6 +89,34 @@ const Hamburger = () => {
             );
           })}
         </nav>
+
+        {/* Contact section */}
+        <div className="shrink-0 px-5 py-5 border-t border-stone-800">
+          <p className="font-label text-[10px] uppercase tracking-widest text-stone-500 mb-3">Connect</p>
+          <div className="flex flex-wrap gap-3 mb-4">
+            {contactData.map((s) => (
+              <a
+                key={s.label}
+                href={s.link}
+                aria-label={s.label}
+                title={s.label}
+                className="flex items-center justify-center w-9 h-9 rounded-full border border-stone-700 text-stone-400 hover:text-secondary hover:border-secondary transition-all"
+              >
+                <FontAwesomeIcon icon={s.icon} size="sm" />
+              </a>
+            ))}
+          </div>
+          <a
+            href={`${process.env.PUBLIC_URL || ''}/sanket-tambare-resume.pdf`}
+            target="_blank"
+            download
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-stone-800 text-stone-200 rounded font-label text-[10px] uppercase tracking-widest font-bold hover:bg-stone-700 transition-all"
+          >
+            <span className="material-symbols-outlined text-[13px]">download</span>
+            Resume PDF
+          </a>
+        </div>
       </div>
     </>,
     document.body,

--- a/src/components/Template/Navigation.js
+++ b/src/components/Template/Navigation.js
@@ -31,17 +31,20 @@ const Navigation = () => {
             
             return (
               <React.Fragment key={l.label}>
-                <div 
+                <div
                   className="relative group"
                   onMouseEnter={() => hasSubRoutes && setOpenDropdown(l.label)}
                   onMouseLeave={() => hasSubRoutes && setOpenDropdown(null)}
+                  onFocus={() => hasSubRoutes && setOpenDropdown(l.label)}
+                  onBlur={(e) => { if (hasSubRoutes && !e.currentTarget.contains(e.relatedTarget)) setOpenDropdown(null); }}
+                  onKeyDown={(e) => { if (e.key === 'Escape') setOpenDropdown(null); }}
                 >
                   <Link
                     to={l.path}
                     className={`px-4 py-2 font-label text-[10px] uppercase tracking-[0.25em] no-underline transition-all flex items-center gap-1 ${
                       isActive
                         ? "text-secondary font-bold"
-                        : "text-stone-400 dark:text-stone-500 hover:text-stone-900 dark:hover:text-stone-100"
+                        : "text-stone-500 dark:text-stone-500 hover:text-stone-900 dark:hover:text-stone-100"
                     }`}
                   >
                     {l.label}
@@ -83,15 +86,20 @@ const Navigation = () => {
           })}
 
           {/* More Dropdown */}
-          <div 
+          <div
             className="relative"
             onMouseEnter={() => setIsMoreDropdownOpen(true)}
             onMouseLeave={() => setIsMoreDropdownOpen(false)}
+            onFocus={() => setIsMoreDropdownOpen(true)}
+            onBlur={(e) => { if (!e.currentTarget.contains(e.relatedTarget)) setIsMoreDropdownOpen(false); }}
+            onKeyDown={(e) => { if (e.key === 'Escape') setIsMoreDropdownOpen(false); }}
           >
             <span className="text-stone-100 dark:text-stone-800 ml-4 pointer-events-none">|</span>
             <button
+              aria-haspopup="true"
+              aria-expanded={isMoreDropdownOpen}
               className={`px-4 py-2 font-label text-[10px] uppercase tracking-[0.25em] no-underline transition-all flex items-center gap-1 ${
-                isMoreDropdownOpen ? "text-stone-900 dark:text-stone-100" : "text-stone-400 dark:text-stone-500 hover:text-stone-900 dark:hover:text-stone-100"
+                isMoreDropdownOpen ? "text-stone-900 dark:text-stone-100" : "text-stone-500 dark:text-stone-500 hover:text-stone-900 dark:hover:text-stone-100"
               }`}
             >
               More

--- a/src/data/changelog.md
+++ b/src/data/changelog.md
@@ -7,6 +7,21 @@ This project does not use semantic versioning; entries are grouped by date and f
 
 ## [v6.1.0] — 2026-04-21
 
+### Added
+- **Skip-to-content link** (`src/layouts/Main.js`): Visible-on-focus skip link added as first focusable element for keyboard users.
+- **Global focus ring** (`src/tailwind.css`): `*:focus-visible` rule applies a 2px `secondary`-coloured outline site-wide so keyboard navigation is always visible.
+- **Mobile contact section** (`src/components/Template/Hamburger.js`): Social icon links and Resume PDF download button added to the bottom of the mobile drawer, closing the gap left by the desktop-only sidebar.
+
+### Changed
+- **Navigation** (`src/components/Template/Navigation.js`): Desktop dropdowns now respond to keyboard focus (`onFocus`/`onBlur`) and close on `Escape`; `aria-haspopup` + `aria-expanded` added to the More button. Inactive link contrast bumped from `stone-400` to `stone-500`.
+- **Footer** (`src/components/Template/Footer.js`): Hover colour changed from `orange-700` to `secondary` to match design system; body text contrast raised from `stone-500` to `stone-600` in light mode.
+- **Sports page** (`src/pages/Sports.js`): Active tab colour unified to `text-secondary` across all three tabs; share button changed from `indigo-500` to `stone-900/stone-100` to match primary button style.
+- **DigitalLibrary** (`src/components/Books/DigitalLibrary.js`): Search input debounced at 300 ms to prevent lag with large lists; book grid `gap-y-16` reduced to `gap-y-8`.
+- **LifeStats** (`src/components/Index/LifeStats.js`): Counters show `—` placeholder before the IntersectionObserver fires instead of "0", preventing a false empty-state appearance.
+- **ProjectGallery** (`src/components/Projects/ProjectGallery.js`): Broken images now render a `broken_image` icon placeholder via `ImageWithFallback` component instead of silently hiding.
+- **TopSummaryCards** (`src/components/Sports/TopSummaryCards.js`): Replaced blue/purple/green card colours with red/secondary/amber to reduce accent-colour sprawl.
+- **SportsStatistics** (`src/components/Sports/SportsStatistics.js`): Sub-summary cards unified to amber/red/secondary/stone; distance bar, personal records, pace, and city count highlights all consolidated to `secondary` and `red-400`.
+
 ### Changed
 - **SportsDefault** (`src/components/Sports/SportsDefault.js`): Redesigned DEFAULT VIEW cards to image-first. Cards now lead with the first `slideImages` entry in a 16:9 container with grayscale-to-color hover transition and overlay. Distance and BIB promoted to image corner badges; footer retains title, date, place, and finish time.
 - **TreksDefault** (`src/components/Treks/TreksDefault.js`): Redesigned DEFAULT VIEW cards to image-first. Cards lead with the first `photos` entry in a 4:3 container with same hover effect. Difficulty and photo count promoted to image corner badges; footer retains fort name, date, trek time, and blog link. Placeholder shown for entries with no images.

--- a/src/layouts/Main.js
+++ b/src/layouts/Main.js
@@ -41,6 +41,7 @@ const Main = (props) => {
       </Helmet>
 
       <div className="flex flex-col min-h-screen bg-white dark:bg-stone-950 text-stone-900 dark:text-stone-100 font-body transition-colors duration-300">
+        <a href="#main" className="skip-link">Skip to main content</a>
         <Navigation />
 
         <div

--- a/src/pages/Sports.js
+++ b/src/pages/Sports.js
@@ -49,15 +49,9 @@ const SportsPage = () => {
           <div className="flex flex-wrap items-center gap-2 bg-stone-100 dark:bg-stone-800/50 p-1.5 rounded-xl">
             {tabs.map((tab) => {
               const isActive = activeTab === tab;
-              let activeColor = "text-stone-900 dark:text-stone-100 bg-white dark:bg-stone-700 shadow-sm";
-              if (isActive) {
-                if (tab === 'STATISTICS') activeColor = "text-green-600 dark:text-green-400 bg-white dark:bg-stone-700 shadow-sm";
-                if (tab === 'INTERACTIVE VIEW') activeColor = "text-purple-600 dark:text-purple-400 bg-white dark:bg-stone-700 shadow-sm";
-                if (tab === 'DEFAULT VIEW') activeColor = "text-blue-600 dark:text-blue-400 bg-white dark:bg-stone-700 shadow-sm";
-              } else {
-                activeColor = "text-stone-500 dark:text-stone-400 hover:text-stone-700 dark:hover:text-stone-300 hover:bg-stone-200/50 dark:hover:bg-stone-800/50";
-              }
-              
+              const activeColor = isActive
+                ? "text-secondary bg-white dark:bg-stone-700 shadow-sm"
+                : "text-stone-500 dark:text-stone-400 hover:text-stone-700 dark:hover:text-stone-300 hover:bg-stone-200/50 dark:hover:bg-stone-800/50";
               return (
                 <button
                   key={tab}
@@ -69,10 +63,10 @@ const SportsPage = () => {
               );
             })}
           </div>
-          
+
           <button
             onClick={handleShare}
-            className="flex items-center gap-2 bg-indigo-500 hover:bg-indigo-600 text-white px-5 py-2.5 rounded-lg font-label text-xs uppercase tracking-widest font-bold transition-colors shadow-sm"
+            className="flex items-center gap-2 bg-stone-900 dark:bg-stone-100 hover:bg-stone-800 dark:hover:bg-stone-200 text-white dark:text-stone-950 px-5 py-2.5 rounded-lg font-label text-xs uppercase tracking-widest font-bold transition-colors shadow-sm"
           >
             <span className="material-symbols-outlined text-[16px]">{copied ? 'check' : 'share'}</span>
             {copied ? 'Copied!' : 'Share'}

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -6,4 +6,18 @@
   body {
     @apply font-body text-stone-300 antialiased bg-[#0c0c0c];
   }
+
+  /* Global keyboard focus ring */
+  *:focus-visible {
+    outline: 2px solid var(--tw-color-secondary, #16a34a);
+    outline-offset: 2px;
+  }
+
+  /* Skip-to-content link */
+  .skip-link {
+    @apply absolute -top-full left-4 z-[9999] bg-stone-900 text-white px-4 py-2 rounded-b font-label text-xs uppercase tracking-widest font-bold transition-all;
+  }
+  .skip-link:focus {
+    @apply top-0;
+  }
 }


### PR DESCRIPTION
## Summary

- **Accessibility**: Added skip-to-content link, global `focus-visible` ring, keyboard navigation for desktop nav dropdowns (`onFocus`/`onBlur`/`Escape`), `aria-expanded` + `aria-haspopup` on More button
- **Mobile sidebar gap**: Contact icons and Resume PDF download added to the Hamburger drawer footer — previously this info was only visible in the desktop sidebar
- **Design system consistency**: Footer hover colour changed from orange to `secondary`; Sports tabs and share button unified to system colours; SportsStatistics/TopSummaryCards reduced from 6+ accent hues to red/secondary/amber
- **Navigation contrast**: Inactive nav links raised from `stone-400` to `stone-500` for WCAG AA compliance
- **UX fixes**: Books search debounced 300ms; book grid `gap-y-16` → `gap-y-8`; LifeStats shows `—` until in viewport; broken project images show a `broken_image` icon placeholder instead of silently disappearing

## Files changed

| File | Change |
|------|--------|
| `src/tailwind.css` | Global focus ring + skip link styles |
| `src/layouts/Main.js` | Skip-to-content link |
| `src/components/Template/Navigation.js` | Keyboard dropdown support, contrast fix |
| `src/components/Template/Footer.js` | Secondary hover colour, contrast bump |
| `src/components/Template/Hamburger.js` | Contact section added to mobile drawer |
| `src/pages/Sports.js` | Unified tab + share button colours |
| `src/components/Sports/TopSummaryCards.js` | Colour system cleanup |
| `src/components/Sports/SportsStatistics.js` | Colour system cleanup |
| `src/components/Books/DigitalLibrary.js` | Debounce search, grid gap fix |
| `src/components/Index/LifeStats.js` | Placeholder until animated |
| `src/components/Projects/ProjectGallery.js` | ImageWithFallback component |
| `src/data/changelog.md` | Updated v6.1.0 entry |

## Test plan

- [ ] Tab through the nav on desktop — dropdowns open on focus and close on Escape
- [ ] Press Tab as first action on any page — skip link should appear and jump to `#main`
- [ ] Open hamburger on mobile — confirm contact icons and PDF download appear at bottom
- [ ] Visit `/sports` — all three tabs should highlight in the same green (secondary) when active; share button should be dark/light themed
- [ ] Visit `/books` — type in search box, verify no lag; confirm grid rows are tighter
- [ ] Visit home and scroll down — LifeStats should show `—` before scrolling into view, then animate

🤖 Generated with [Claude Code](https://claude.com/claude-code)